### PR TITLE
Update GitFileSystemProvider - Fixes #9

### DIFF
--- a/parallelgit-filesystem/src/main/java/com/beijunyi/parallelgit/filesystem/GitFileSystemProvider.java
+++ b/parallelgit-filesystem/src/main/java/com/beijunyi/parallelgit/filesystem/GitFileSystemProvider.java
@@ -215,16 +215,7 @@ public class GitFileSystemProvider extends FileSystemProvider {
 
   @Nonnull
   private static GitFileSystemProvider getInstalledProvider() {
-    GitFileSystemProvider ret = null;
-    for(FileSystemProvider provider : FileSystemProvider.installedProviders()) {
-      if(provider instanceof GitFileSystemProvider) {
-        ret = (GitFileSystemProvider) provider;
-        break;
-      }
-    }
-    if(ret == null)
-      ret = new GitFileSystemProvider();
-    return ret;
+    return new GitFileSystemProvider();
   }
 
   @Nonnull


### PR DESCRIPTION
getInstalledProvider() makes a call to FileSystemProvider.installedProviders() which can cause circular dependencies when called by getInstalledProvider() which in turn calls loadInstalledProviders() the first time. 

Refer to Issue #9 for more info.
